### PR TITLE
refactor: improve SQL query formatting and code readability

### DIFF
--- a/src-tauri/src/user_settings/mod.rs
+++ b/src-tauri/src/user_settings/mod.rs
@@ -36,7 +36,6 @@ const ONLY_ONE_USER_SETTINGS: RowId = 1;
 /// Ensure user settings exist, creating them if necessary.
 pub async fn ensure_exists<A: FiatExchanger + Default>(db: &Db) -> Result<UserSettings> {
     if exists(db).await? {
-        println!("User settings already exists");
         return get(db).await;
     }
 
@@ -102,7 +101,7 @@ pub async fn get(db: &Db) -> Result<UserSettings> {
     use sqlx::Row;
     let row = sqlx::query(
         r#"
-        SELECT 
+        SELECT
             u.id, u.locale, u.default_fiat_id,
             f.id as f_id, f.symbol as f_symbol, f.name as f_name
         FROM user_settings u


### PR DESCRIPTION
## Summary
- Refactor SQL queries to use multi-line raw string literals (`r#""#`) for improved readability
- Improve code formatting and indentation across fiat ramp and rate modules
- Remove unnecessary debug print statement from user settings