### PR TITLE
fix: adjust layout for macOS overlay title bar and traffic lights

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,7 +14,9 @@
       {
         "title": "Aura",
         "width": 800,
-        "height": 600
+        "height": 600,
+        "titleBarStyle": "overlay",
+        "hiddenTitle": true
       }
     ],
     "security": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,14 +25,18 @@ function AppContent() {
         onHide={() => setSidebarVisible(false)}
       />
 
-      <div className="sticky top-0 z-50 bg-base-100 p-4 shadow-sm">
+      {/* Navbar with macOS traffic light padding */}
+      <div 
+        className="sticky top-0 z-50 bg-background pt-8 pb-4 px-4 shadow-sm flex items-center gap-2"
+        data-tauri-drag-region
+      >
         <Button onClick={() => setSidebarVisible(true)} variant="outline">
           <PanelRightOpen />
         </Button>
         <ModeToggle />
       </div>
       <div className="flex flex-col gap-4 p-4 max-w-7xl mx-auto w-full">
-        <div className="flex-grow bg-base-100 shadow-xl rounded-box p-4 w-full">
+        <div className="flex-grow bg-background shadow-xl rounded-lg p-4 w-full">
           <Routes>
             {AppRoutes.map((route, index) => (
               <Route key={index} path={route.path} element={route.element} />

--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -24,7 +24,7 @@ export default function Sidebar({ visible, onHide }: SidebarProps) {
 
     return (
         <Sheet open={visible} onOpenChange={(open) => !open && onHide()}>
-            <SheetContent side="left" className="w-full md:w-[20rem] lg:w-[30rem]">
+            <SheetContent side="left" className="w-full md:w-[20rem] lg:w-[30rem] pt-10">
                 <SheetHeader className="mb-4 text-left">
                     <SheetTitle>Navigation</SheetTitle>
                     <SheetDescription className="sr-only">


### PR DESCRIPTION
## Summary

- Enable macOS overlay title bar with hidden title for a modern, clean look
- Add proper padding to navbar and sidebar to prevent content overlap with macOS traffic lights (close/minimize/maximize buttons)
- Add drag region to navbar so users can drag the window from the top bar
- Replace `bg-base-100` (DaisyUI) with `bg-background` (shadcn/ui) for proper theme support

## Changes

| File | Change |
|------|--------|
| `src-tauri/tauri.conf.json` | Added `titleBarStyle: "overlay"` and `hiddenTitle: true` |
| `src/App.tsx` | Added `pt-8` padding, `data-tauri-drag-region`, and fixed background class |
| `src/components/common/Sidebar.tsx` | Added `pt-10` padding to clear traffic lights |