### PR TITLE
feat: Funding Summary Cards & Date Filtering

### DIFF
--- a/src-tauri/src/fiat_ramp/command.rs
+++ b/src-tauri/src/fiat_ramp/command.rs
@@ -39,12 +39,34 @@ pub async fn get_fiat_ramps(
     offset: Option<u32>,
     query: Option<String>,
     sort: Option<SortOptions>,
+    start_date: Option<chrono::NaiveDate>,
+    end_date: Option<chrono::NaiveDate>,
 ) -> Result<FiatRampPagination, String> {
     let limit = limit.unwrap_or(50);
     let offset = offset.unwrap_or(0);
-    FiatRampService::get(limit, offset, query, sort, &db)
+    FiatRampService::get(limit, offset, query, sort, start_date, end_date, &db)
         .await
         .map_err(|e| format!("failed to get all fiat ramps: {e}"))
+}
+
+/// Get fiat ramp summary
+#[tauri::command]
+pub async fn get_fiat_ramp_summary(
+    db: State<'_, Db>,
+    start_date: Option<chrono::NaiveDate>,
+    end_date: Option<chrono::NaiveDate>,
+) -> Result<crate::fiat_ramp::FiatRampSummary, String> {
+    FiatRampService::get_summary(start_date, end_date, &db)
+        .await
+        .map_err(|e| format!("failed to get fiat ramp summary: {e}"))
+}
+
+/// Get fiat ramp date range (min and max date)
+#[tauri::command]
+pub async fn get_fiat_ramp_date_range(
+    db: State<'_, Db>,
+) -> Result<(Option<chrono::NaiveDate>, Option<chrono::NaiveDate>), String> {
+    FiatRampService::get_date_range(&db).await
 }
 
 /// Update a fiat ramp

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -50,7 +50,9 @@ pub fn run() {
                 let db_for_task = Db(db.0.clone());
                 tauri::async_runtime::spawn(async move {
                     let api = FrankfurterExchangerApi::default();
-                    if let Err(e) = crate::fiat_rate::process_missing_rates(&db_for_task, &api).await {
+                    if let Err(e) =
+                        crate::fiat_rate::process_missing_rates(&db_for_task, &api).await
+                    {
                         eprintln!("Failed to process missing rates: {}", e);
                     }
                 });
@@ -68,6 +70,8 @@ pub fn run() {
             fiat_ramp_command::get_fiat_ramps,
             fiat_ramp_command::update_fiat_ramp,
             fiat_ramp_command::delete_fiat_ramp,
+            fiat_ramp_command::get_fiat_ramp_summary,
+            fiat_ramp_command::get_fiat_ramp_date_range,
             user_settings_command::get_user_settings,
             user_settings_command::update_user_settings,
         ])

--- a/src/components/common/date-range-filter.tsx
+++ b/src/components/common/date-range-filter.tsx
@@ -1,0 +1,138 @@
+import { format, subWeeks, subMonths, subYears } from "date-fns"
+import { Calendar as CalendarIcon } from "lucide-react"
+import { DateRange } from "react-day-picker"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Calendar } from "@/components/ui/calendar"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { FiatRampCommand } from "@/lib/services/funding/fiatRamp.command"
+
+interface DateRangeFilterProps {
+  date: DateRange | undefined
+  setDate: (date: DateRange | undefined) => void
+  className?: string
+}
+
+export function DateRangeFilter({
+  date,
+  setDate,
+  className,
+}: DateRangeFilterProps) {
+  const handlePresetChange = async (value: string) => {
+    const end = new Date()
+    let start: Date | undefined
+    let customEnd: Date | undefined
+
+    switch (value) {
+      case "1week":
+        start = subWeeks(end, 1)
+        break
+      case "2weeks":
+        start = subWeeks(end, 2)
+        break
+      case "1month":
+        start = subMonths(end, 1)
+        break
+      case "3months":
+        start = subMonths(end, 3)
+        break
+      case "6months":
+        start = subMonths(end, 6)
+        break
+      case "1year":
+        start = subYears(end, 1)
+        break
+      case "all":
+        try {
+            const [min, max] = await FiatRampCommand.getDateRange();
+            if (min) start = new Date(min);
+            if (max) customEnd = new Date(max);
+            
+            // If we found a start date, set the range. 
+            // If customEnd is found use it, otherwise use 'now' (though data might be in future? unlikely for ramps but safer to use max)
+            if (start) {
+                setDate({ from: start, to: customEnd || end })
+            } else {
+                // If no data exists, maybe clear filter?
+                setDate(undefined) 
+            }
+        } catch (e) {
+            console.error("Failed to fetch date range", e);
+            // Fallback to clearing filter or default
+            setDate(undefined)
+        }
+        return
+    }
+
+    if (start) {
+      setDate({ from: start, to: end })
+    }
+  }
+
+  return (
+    <div className={cn("flex items-center gap-2", className)}>
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            id="date"
+            variant={"outline"}
+            className={cn(
+              "w-[300px] justify-start text-left font-normal",
+              !date && "text-muted-foreground"
+            )}
+          >
+            <CalendarIcon className="mr-2 h-4 w-4" />
+            {date?.from ? (
+              date.to ? (
+                <>
+                  {format(date.from, "LLL dd, y")} -{" "}
+                  {format(date.to, "LLL dd, y")}
+                </>
+              ) : (
+                format(date.from, "LLL dd, y")
+              )
+            ) : (
+              <span>Pick a date range</span>
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-auto p-0" align="start">
+          <Calendar
+            initialFocus
+            mode="range"
+            defaultMonth={date?.from}
+            selected={date}
+            onSelect={setDate}
+            numberOfMonths={2}
+          />
+        </PopoverContent>
+      </Popover>
+      <Select onValueChange={handlePresetChange}>
+        <SelectTrigger className="w-[120px]">
+          <SelectValue placeholder="Presets" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="1week">1 Week</SelectItem>
+          <SelectItem value="2weeks">2 Weeks</SelectItem>
+          <SelectItem value="1month">1 Month</SelectItem>
+          <SelectItem value="3months">3 Months</SelectItem>
+          <SelectItem value="6months">6 Months</SelectItem>
+          <SelectItem value="1year">1 Year</SelectItem>
+          <SelectItem value="all">All Time</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}

--- a/src/components/funding/funding-chart-summary.tsx
+++ b/src/components/funding/funding-chart-summary.tsx
@@ -16,9 +16,11 @@ type ChartType = "bar" | "line";
 
 interface FundingChartSummaryProps {
   refreshTrigger?: number;
+  startDate?: Date | null;
+  endDate?: Date | null;
 }
 
-export default function FundingChartSummary({ refreshTrigger }: FundingChartSummaryProps) {
+export default function FundingChartSummary({ refreshTrigger, startDate, endDate }: FundingChartSummaryProps) {
   const [fiatRamps, setFiatRamps] = useState<FiatRampView[]>([]);
   const [targetCurrency, setTargetCurrency] = useState<Fiat | null>(null);
   const [chartType, setChartType] = useState<ChartType>("bar");
@@ -34,7 +36,7 @@ export default function FundingChartSummary({ refreshTrigger }: FundingChartSumm
       setTargetCurrency(target || null);
 
       // Load all fiat ramps (no pagination for chart)
-      const result = await FiatRampCommand.get(1000, 0);
+      const result = await FiatRampCommand.get(1000, 0, undefined, undefined, startDate, endDate);
       setFiatRamps(result.fiat_ramps);
     } catch (error) {
       console.error("Failed to load chart data:", error);
@@ -45,7 +47,7 @@ export default function FundingChartSummary({ refreshTrigger }: FundingChartSumm
 
   useEffect(() => {
     loadData();
-  }, [refreshTrigger]);
+  }, [refreshTrigger, startDate, endDate]);
 
   // Aggregate converted amounts by date
   const chartData = useMemo(() => {

--- a/src/components/funding/funding-summary-cards.tsx
+++ b/src/components/funding/funding-summary-cards.tsx
@@ -1,0 +1,117 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { FiatRampCommand } from "@/lib/services/funding/fiatRamp.command";
+import { FiatRampSummary } from "@/lib/models/fiatRamp";
+import { useEffect, useState } from "react";
+import { ArrowDownLeft, ArrowUpRight, Wallet } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+interface FundingSummaryCardsProps {
+  refreshTrigger?: number;
+  startDate?: Date | null;
+  endDate?: Date | null;
+}
+
+export default function FundingSummaryCards({
+  refreshTrigger,
+  startDate,
+  endDate,
+}: FundingSummaryCardsProps) {
+  const [summary, setSummary] = useState<FiatRampSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchSummary = async () => {
+      try {
+        setLoading(true);
+        const data = await FiatRampCommand.getSummary(startDate || undefined, endDate || undefined);
+        setSummary(data);
+      } catch (error) {
+        console.error("Failed to fetch funding summary:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchSummary();
+  }, [refreshTrigger, startDate, endDate]);
+
+  const totalInvested =
+    (summary?.total_deposit ?? 0) - (summary?.total_withdraw ?? 0);
+  const currencySymbol = summary?.fiat_symbol ?? "$";
+
+  return (
+    <TooltipProvider>
+      <div className="grid gap-4 md:grid-cols-3 mb-4">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">
+              <Tooltip>
+                <TooltipTrigger className="flex items-center gap-1 cursor-help">
+                  Total Deposits
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Total funds deposited</p>
+                </TooltipContent>
+              </Tooltip>
+            </CardTitle>
+            <ArrowDownLeft className="h-4 w-4 text-green-500" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {loading
+                ? "..."
+                : `${currencySymbol} ${summary?.total_deposit?.toFixed(2) ?? "0.00"}`}
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">
+              <Tooltip>
+                <TooltipTrigger className="flex items-center gap-1 cursor-help">
+                  Total Withdrawals
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Total funds withdrawn</p>
+                </TooltipContent>
+              </Tooltip>
+            </CardTitle>
+            <ArrowUpRight className="h-4 w-4 text-red-500" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {loading
+                ? "..."
+                : `${currencySymbol} ${summary?.total_withdraw?.toFixed(2) ?? "0.00"}`}
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">
+              <Tooltip>
+                <TooltipTrigger className="flex items-center gap-1 cursor-help">
+                  Total Invested
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Net investment (Deposits - Withdrawals)</p>
+                </TooltipContent>
+              </Tooltip>
+            </CardTitle>
+            <Wallet className="h-4 w-4 text-blue-500" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {loading ? "..." : `${currencySymbol} ${totalInvested.toFixed(2)}`}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/src/components/funding/funding-table.tsx
+++ b/src/components/funding/funding-table.tsx
@@ -46,9 +46,11 @@ import { FiatRampCommand } from "@/lib/services/funding/fiatRamp.command";
 interface FundingTableProps {
   refreshTrigger?: number;
   onDataChange?: () => void;
+  startDate?: Date | null;
+  endDate?: Date | null;
 }
 
-export default function FundingTable({ refreshTrigger, onDataChange }: FundingTableProps) {
+export default function FundingTable({ refreshTrigger, onDataChange, startDate, endDate }: FundingTableProps) {
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
     pageSize: 5,
@@ -90,12 +92,14 @@ export default function FundingTable({ refreshTrigger, onDataChange }: FundingTa
       offset,
       globalFilter,
       sortOptions,
+      startDate,
+      endDate
     ).then((res) => {
       setFunding(res.fiat_ramps);
       setTotalRecords(res.total_count);
       setLoading(false);
     });
-  }, [pagination.pageIndex, pagination.pageSize, globalFilter, sorting]);
+  }, [pagination.pageIndex, pagination.pageSize, globalFilter, sorting, startDate, endDate]);
 
   useEffect(() => {
     loadData();

--- a/src/components/funding/funding.tsx
+++ b/src/components/funding/funding.tsx
@@ -2,6 +2,9 @@ import { useState } from "react";
 import FundingTable from "./funding-table";
 import FundingCreateForm from "./funding-create";
 import FundingChartSummary from "./funding-chart-summary";
+import FundingSummaryCards from "./funding-summary-cards";
+import { DateRangeFilter } from "@/components/common/date-range-filter";
+import { useFundingDateFilter } from "@/hooks/use-funding-date-filter";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -15,6 +18,7 @@ import { Plus } from "lucide-react";
 export default function Funding() {
   const [createDialogVisible, setCreateDialogVisible] = useState(false);
   const [refreshTrigger, setRefreshTrigger] = useState(0);
+  const { dateRange, setDateRange } = useFundingDateFilter();
 
   const onCreated = () => {
     setRefreshTrigger((prev) => prev + 1);
@@ -29,16 +33,33 @@ export default function Funding() {
 
   return (
     <div>
-      <div className="mb-4 flex justify-end">
+      <div className="mb-4 flex justify-between items-center">
+        <DateRangeFilter date={dateRange} setDate={setDateRange} />
         <Button onClick={() => setCreateDialogVisible(true)}>
           <Plus className="mr-2 h-4 w-4" />
           Deposit / Withdraw
         </Button>
       </div>
       <div className="mb-4">
-        <FundingChartSummary refreshTrigger={refreshTrigger} />
+        <FundingSummaryCards
+          refreshTrigger={refreshTrigger}
+          startDate={dateRange?.from}
+          endDate={dateRange?.to}
+        />
       </div>
-      <FundingTable refreshTrigger={refreshTrigger} onDataChange={onTableDataChange} />
+      <div className="mb-4">
+        <FundingChartSummary
+          refreshTrigger={refreshTrigger}
+          startDate={dateRange?.from}
+          endDate={dateRange?.to}
+        />
+      </div>
+      <FundingTable 
+        refreshTrigger={refreshTrigger} 
+        onDataChange={onTableDataChange}
+        startDate={dateRange?.from}
+        endDate={dateRange?.to}
+      />
 
       <Dialog open={createDialogVisible} onOpenChange={setCreateDialogVisible}>
         <DialogContent>

--- a/src/hooks/use-funding-date-filter.ts
+++ b/src/hooks/use-funding-date-filter.ts
@@ -1,0 +1,50 @@
+import { useState, useEffect } from "react";
+import { DateRange } from "react-day-picker";
+import { subWeeks } from "date-fns";
+
+const STORAGE_KEY = "funding_date_filter_range";
+
+export function useFundingDateFilter() {
+  const [dateRange, setDateRange] = useState<DateRange | undefined>(() => {
+    // 1. Try to load from localStorage
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored);
+        if (parsed.from && parsed.to) {
+          return {
+            from: new Date(parsed.from),
+            to: new Date(parsed.to),
+          };
+        }
+      } catch (e) {
+        console.error("Failed to parse stored date range", e);
+      }
+    }
+
+    // 2. Default to last 2 weeks if nothing stored
+    const end = new Date();
+    const start = subWeeks(end, 2);
+    return {
+      from: start,
+      to: end,
+    };
+  });
+
+  // Update localStorage whenever dateRange changes
+  useEffect(() => {
+    if (dateRange?.from && dateRange?.to) {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          from: dateRange.from.toISOString(),
+          to: dateRange.to.toISOString(),
+        })
+      );
+    } else {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+  }, [dateRange]);
+
+  return { dateRange, setDateRange };
+}

--- a/src/lib/models/fiatRamp.ts
+++ b/src/lib/models/fiatRamp.ts
@@ -48,3 +48,10 @@ export interface FiatRampPagination {
   total_count: number;
   fiat_ramps: FiatRampView[];
 }
+
+export interface FiatRampSummary {
+  total_deposit: number;
+  total_withdraw: number;
+  fiat_symbol: string;
+  fiat_name: string;
+}

--- a/src/lib/services/funding/fiatRamp.command.ts
+++ b/src/lib/services/funding/fiatRamp.command.ts
@@ -1,5 +1,5 @@
 import { StringRowId } from "@/lib/models/common";
-import { CreateFiatRamp, FiatRampPagination, UpdateFiatRamp, SortOptions } from "@/lib/models/fiatRamp";
+import { CreateFiatRamp, FiatRampPagination, UpdateFiatRamp, SortOptions, FiatRampSummary } from "@/lib/models/fiatRamp";
 import { invoke } from "@tauri-apps/api/core";
 import { format } from "date-fns";
 
@@ -7,7 +7,9 @@ enum FiatRampCommandList {
     CREATE = 'create_fiat_ramp',
     GET = 'get_fiat_ramps',
     UPDATE = 'update_fiat_ramp',
-    DELETE = 'delete_fiat_ramp'
+    DELETE = 'delete_fiat_ramp',
+    GET_SUMMARY = 'get_fiat_ramp_summary',
+    GET_DATE_RANGE = 'get_fiat_ramp_date_range'
 }
 
 
@@ -36,10 +38,19 @@ export class FiatRampCommand {
      * @param offset Optional offset for pagination
      * @param query Optional query for search
      * @param sort Optional sorting options
+     * @param startDate Optional start date filter
+     * @param endDate Optional end date filter
      * @returns FiatRampPagination
      */
-    public static get(limit?: number, offset?: number, query?: string, sort?: SortOptions) {
-        return invoke<FiatRampPagination>(FiatRampCommandList.GET, { limit, offset, query, sort });
+    public static get(limit?: number, offset?: number, query?: string, sort?: SortOptions, startDate?: Date | null, endDate?: Date | null) {
+        return invoke<FiatRampPagination>(FiatRampCommandList.GET, { 
+            limit, 
+            offset, 
+            query, 
+            sort,
+            startDate: startDate ? format(startDate, 'yyyy-MM-dd') : undefined,
+            endDate: endDate ? format(endDate, 'yyyy-MM-dd') : undefined
+        });
     }
 
     /**
@@ -67,5 +78,26 @@ export class FiatRampCommand {
      */
     public static delete(id: StringRowId) {
         return invoke<number>(FiatRampCommandList.DELETE, { id });
+    }
+
+    /**
+     * Get fiat ramp summary
+     * @param startDate Optional start date filter
+     * @param endDate Optional end date filter
+     * @returns FiatRampSummary
+     */
+    public static getSummary(startDate?: Date | null, endDate?: Date | null) {
+        return invoke<FiatRampSummary>(FiatRampCommandList.GET_SUMMARY, {
+            startDate: startDate ? format(startDate, 'yyyy-MM-dd') : undefined,
+            endDate: endDate ? format(endDate, 'yyyy-MM-dd') : undefined
+        });
+    }
+
+    /**
+     * Get the min and max date of all fiat ramps
+     * @returns [string | null, string | null] (min_date, max_date)
+     */
+    public static getDateRange() {
+        return invoke<[string | null, string | null]>(FiatRampCommandList.GET_DATE_RANGE);
     }
 }


### PR DESCRIPTION
## Summary
This PR introduces a new "Funding Summary Cards" section to the Funding page, displaying Total Deposits, Total Withdrawals, and Total Invested. It also adds a robust date range filtering system that affects the cards, the chart, and the transaction table.

## Changes
- **Frontend:**
    - New `FundingSummaryCards` component.
    - New `DateRangeFilter` component with presets (1W, 2W, 1M, 3M, 6M, 1Y, All Time).
    - `All Time` preset dynamically fetches the min/max date range from the DB.
    - New `useFundingDateFilter` hook to persist filter selection in `localStorage`.
    - Updated `Funding` page to coordinate the filter state.
- **Backend:**
    - New `get_fiat_ramp_summary` command.
    - New `get_fiat_ramp_date_range` command.
    - Updated `get_fiat_ramps` to accept start/end dates.